### PR TITLE
Enable UTF8 characters generation.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "main": [
     "js/qrcode.js",
     "js/qrcode_UTF8.js"
+    ],
   "ignore": [
     "**/.*",
     "node_modules",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "qrcode-generator",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": [
     "js/qrcode.js",
     "js/qrcode_UTF8.js"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "qrcode-generator",
   "version": "0.0.2",
-  "main": "js/qrcode.js",
+  "main": "js/qrcode_UTF8.js",
   "ignore": [
     "**/.*",
     "node_modules",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "qrcode-generator",
-  "version": "0.0.4",
+  "version": "0.0.3",
   "main": [
     "js/qrcode.js",
     "js/qrcode_UTF8.js"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,9 @@
 {
   "name": "qrcode-generator",
   "version": "0.0.3",
-  "main": "js/qrcode_UTF8.js",
+  "main": [
+    "js/qrcode.js",
+    "js/qrcode_UTF8.js"
   "ignore": [
     "**/.*",
     "node_modules",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "qrcode-generator",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "js/qrcode_UTF8.js",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Add file "qrcode_UTF8.js" as one of the main files into **bower.json** to enable UTF8(Japanese) characters generation. Therefore the qrcode_UFT8.js can be installed automatically together with qrcode.js by bower, when other developers want to use UTF8 characters in their project. This has been tested at my local environment.
